### PR TITLE
Use isUp() when checking server status to respect availability status

### DIFF
--- a/orderedLeastOutstanding.lua
+++ b/orderedLeastOutstanding.lua
@@ -41,7 +41,7 @@ function orderedLeastOutstanding(servers, dq)
 	while servers[i] do
 
 		-- We only care if the server is currently up
-		if (servers[i].upStatus == true) then
+		if (servers[i]:isUp()) then
 
 			-- Retrieve the order for the server
 			order = servers[i].order


### PR DESCRIPTION
Use `isUp()` when checking server status to respect availability status when servers are set to `DOWN` state with `setDown()`.

During testing of this server policy, I explicitly set my order `1` server to `DOWN` using `setDown()` which resulting in the query timing out as `upStatus` does not respect availability status from `setDown()`.